### PR TITLE
use AddCSLuaFile instead of resource.AddWorkshop. fixes client error.

### DIFF
--- a/lua/autorun/physgun_glow_autorun.lua
+++ b/lua/autorun/physgun_glow_autorun.lua
@@ -7,7 +7,8 @@ PhysgunGlow.Print = function( msg )
 end
 
 if SERVER then
-	resource.AddWorkshop( "111249028" )
+	AddCSLuaFile( "physgunglow/util.lua" )
+	AddCSLuaFile( "physgunglow/glow.lua" )
 else
 	PhysgunGlow.Print( "Loading Physgun Glow" )
 	include( "physgunglow/glow.lua" )


### PR DESCRIPTION
When using a dedicated server and a client, using this addon from the workshop generates an error upon player join, saying the include('physgunglow/glow.lua) fails.
I read that AddCSLuaFile is necessary (seems adding from workshop does not work anymore), fixed it, and tested. Worked on the dedicated server + client setup.
My steam id is http://steamcommunity.com/id/skar_/ , just in case.
