### PR TITLE
Check if view is nil and use player:eyepos to measure distance in that case

### DIFF
--- a/lua/physgunglow/util.lua
+++ b/lua/physgunglow/util.lua
@@ -26,7 +26,7 @@ PhysgunGlow.ShouldGlow = function( ply )
 
 	--CVar (Max Dist)
 	if ( !enable:GetBool() ) then return false end
-	if ( ply:GetPos():Distance( view.origin or ply:GetPos() ) > maxdist:GetInt() ) then return false end
+	if ( ply:GetPos():Distance( view and view.origin or LocalPlayer():EyePos() ) > maxdist:GetInt() ) then return false end
 
 	--Weapon specific
 	local weapon_e = ply:GetActiveWeapon()


### PR DESCRIPTION
When view is nil,instead of erroring, use local player eye pos (assumes the actual view is somehow linked to player).
This all because of a comment in the workshop regarding stationary guns. Tried to get the corresponding addon running, still have texture errors but after this edit no more "gun wall glow" errors.
