### PR TITLE
if view is nil use ply:GetPos() too.

### DIFF
--- a/lua/physgunglow/util.lua
+++ b/lua/physgunglow/util.lua
@@ -26,7 +26,7 @@ PhysgunGlow.ShouldGlow = function( ply )
 
 	--CVar (Max Dist)
 	if ( !enable:GetBool() ) then return false end
-	if ( ply:GetPos():Distance( view.origin or ply:GetPos() ) > maxdist:GetInt() ) then return false end
+	if ( ply:GetPos():Distance( (view and view.origin) or ply:GetPos() ) > maxdist:GetInt() ) then return false end
 
 	--Weapon specific
 	local weapon_e = ply:GetActiveWeapon()


### PR DESCRIPTION
This fixes issue #1 . Tested with the corresponding addon installed (some textures would error for me but physgunglow errors stopped).
